### PR TITLE
Workflows for publishing to Confluence

### DIFF
--- a/.github/workflows/publish_attest.yaml
+++ b/.github/workflows/publish_attest.yaml
@@ -1,0 +1,31 @@
+name: Publish to Confluence
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20        
+      
+      - name: Rename all .md files
+        run: find . -depth -name "*.md" -exec sh -c 'f="{}"; mv -- "$f" "$(dirname "$f")/attest_$(basename "$f")"' \;
+
+      - name: Replace comments with a space
+        run: find . -type f -name "*.md" -exec sed -i 's/<!--.*-->/ /g' {} +  
+
+      - name: Remove <p> and </p> tags
+        run: find . -type f -name "*.md" -exec sed -i 's/<\/\?p>//g' {} + 
+
+      - name: Publish Markdown to Confluence
+        uses: markdown-confluence/publish-action@v5
+        with:
+          confluenceBaseUrl: https://ledgerhq.atlassian.net/
+          confluenceParentId: 5036769289
+          atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
+          atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+          folderToPublish: .
+          contentRoot: actions/attest/
+          #configFile: .markdown-confluence.json

--- a/.github/workflows/publish_jfrog_login.yaml
+++ b/.github/workflows/publish_jfrog_login.yaml
@@ -1,0 +1,31 @@
+name: Publish to Confluence
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+    
+      - name: Rename all .md files
+        run: find . -depth -name "*.md" -exec sh -c 'f="{}"; mv -- "$f" "$(dirname "$f")/jfrog_login_$(basename "$f")"' \;
+
+      - name: Replace comments with a space
+        run: find . -type f -name "*.md" -exec sed -i 's/<!--.*-->/ /g' {} +     
+
+      - name: Remove <p> and </p> tags
+        run: find . -type f -name "*.md" -exec sed -i 's/<\/\?p>//g' {} + 
+
+      - name: Publish Markdown to Confluence
+        uses: markdown-confluence/publish-action@v5
+        with:
+          confluenceBaseUrl: https://ledgerhq.atlassian.net/
+          confluenceParentId: 5036769289
+          atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
+          atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+          folderToPublish: .
+          contentRoot: actions/jfrog-login/
+          #configFile: .markdown-confluence.json

--- a/.github/workflows/publish_sign_blob.yaml
+++ b/.github/workflows/publish_sign_blob.yaml
@@ -1,0 +1,31 @@
+name: Publish to Confluence
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20         
+      
+      - name: Rename all .md files
+        run: find . -depth -name "*.md" -exec sh -c 'f="{}"; mv -- "$f" "$(dirname "$f")/sign_blob_$(basename "$f")"' \;
+
+      - name: Replace comments with a space
+        run: find . -type f -name "*.md" -exec sed -i 's/<!--.*-->/ /g' {} + 
+        
+      - name: Remove <p> and </p> tags
+        run: find . -type f -name "*.md" -exec sed -i 's/<\/\?p>//g' {} + 
+
+      - name: Publish Markdown to Confluence
+        uses: markdown-confluence/publish-action@v5
+        with:
+          confluenceBaseUrl: https://ledgerhq.atlassian.net/
+          confluenceParentId: 5036769289
+          atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
+          atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+          folderToPublish: .
+          contentRoot: actions/sign-blob/
+          #configFile: .markdown-confluence.json

--- a/.github/workflows/publish_sign_container.yaml
+++ b/.github/workflows/publish_sign_container.yaml
@@ -1,0 +1,31 @@
+name: Publish to Confluence
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20 
+      
+      - name: Rename all .md files
+        run: find . -depth -name "*.md" -exec sh -c 'f="{}"; mv -- "$f" "$(dirname "$f")/sign_container_$(basename "$f")"' \;
+
+      - name: Replace comments with a space
+        run: find . -type f -name "*.md" -exec sed -i 's/<!--.*-->/ /g' {} +  
+
+      - name: Remove <p> and </p> tags
+        run: find . -type f -name "*.md" -exec sed -i 's/<\/\?p>//g' {} + 
+
+      - name: Publish Markdown to Confluence
+        uses: markdown-confluence/publish-action@v5
+        with:
+          confluenceBaseUrl: https://ledgerhq.atlassian.net/
+          confluenceParentId: 5036769289
+          atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
+          atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+          folderToPublish: .
+          contentRoot: actions/sign-container/
+          #configFile: .markdown-confluence.json


### PR DESCRIPTION
These workflows are one way to publish from GitHub to Confluence. Outcome is viewable here: https://ledgerhq.atlassian.net/wiki/spaces/SE/pages/5036769289/GitHub+Tests
Another way is to use a Confluence plugin. Outcome is viewable here: https://ledgerhq.atlassian.net/wiki/spaces/SE/pages/5186060332/GitHub+Tests+2
If we choose the workflows and not the plugin, then we should merge this PR.