### PR TITLE
feat(sign-blob): add option to allow sign-blob even on private repo

### DIFF
--- a/actions/sign-blob/action.yml
+++ b/actions/sign-blob/action.yml
@@ -9,19 +9,22 @@ inputs:
     description: 'Path to the artifact, directory, or glob pattern to match files for signing'
     required: true
     default: ""
+  allow_private:
+    description: 'If set to "true", will sign even if the repo is private'
+    default: "false"
 
 runs:
   using: "composite"
   steps:
     - name: Check if repository is public (signature are leaking private information)
-      if: ${{ github.event.repository.visibility != 'public' }}
+      if: ${{ github.event.repository.visibility != 'public' && inputs.allow_private != 'true' }}
       shell: bash
       run: echo "This action only runs on public repositories. To avoid leaking private information, the action will be stopped."
     - name: Install Cosign
-      if: ${{ github.event.repository.visibility == 'public' }}
+      if: ${{ github.event.repository.visibility == 'public' || inputs.allow_private == 'true' }}
       uses: sigstore/cosign-installer@v3
     - name: Sign Blobs
-      if: ${{ github.event.repository.visibility == 'public' }}
+      if: ${{ github.event.repository.visibility == 'public' || inputs.allow_private == 'true' }}
       shell: python
       run: |
         import os


### PR DESCRIPTION
Initial context: **[VG-24075 - Publish types, sdk & cli on npm](https://ledgerhq.atlassian.net/browse/VG-24075)** for **[revault](https://github.com/LedgerHQ/revault)** monorepo.

We were initially planning to publicly publish those three JS libs the same way we already do on our private repo [vault-ts](https://github.com/LedgerHQ/vault-ts), a.k.a by having the NPM token at repo level and use it.

However, the [corresponding access ticket](https://ledgerhq.atlassian.net/browse/ACCESS-11587) to get the NPM token got denied because we are now expected to publish on JFrog and let JFrog handle the npm publish.

So, we added a dedicated step on our release job to publish on JFrog (see https://github.com/LedgerHQ/revault/pull/2146).

But then, we are now getting stopped because the suggested action`LedgerHQ/actions-security/actions/sign-blob` is requiring repo to be public (see [this run](https://github.com/LedgerHQ/revault/actions/runs/14893420359/job/41830861377)):

![1746720884](https://github.com/user-attachments/assets/649d4f04-67ae-4c47-acc6-430136af94a4)

As we are not planning to make the repo public for now, but still want to publish _some built assets_ in public (e.g: the TypeScript types exposed by revault-api, or the SDK to be used by client), we are kind of blocked again.

Hence, this PR is adding a new option `allow_private` on `sign-blob` action, that will explicitly allow to still sign the output artifacts even if the repo is not public.

WDYT?

_Side-note: It seems that even if we pass this, nothing will be uploaded on JFrog, unless I'm missing the point of this TODO:_ https://github.com/LedgerHQ/actions-security/blob/3868be0ef1ec8722fbdb2c6cda90f739cbfc742d/actions/sign-blob/action.yml#L77

\+ Can you confirm that JFrog will properly handle the publish to npm? Or did we got it wrong from the beginning?

Thanks!