### PR TITLE
feat(attest-npmjs-com): validate repository.url before generating attestation

### DIFF
--- a/actions/attest-for-npmsjs-com/action.yml
+++ b/actions/attest-for-npmsjs-com/action.yml
@@ -147,6 +147,29 @@ runs:
             exit 1
           fi
 
+          EXPECTED_REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
+
+          REPO_URL=$(jq -r '
+            if .repository | type == "object" then .repository.url // ""
+            elif .repository | type == "string" then .repository
+            else ""
+            end
+          ' <<<"$PACKAGE_JSON")
+
+          if [ -z "$REPO_URL" ]; then
+            echo "::error::package.json is missing the \"repository\" field. npmjs.com provenance verification requires \"repository.url\" to match \"${EXPECTED_REPO_URL}\". Add to your package.json: \"repository\": { \"type\": \"git\", \"url\": \"${EXPECTED_REPO_URL}\" }"
+            exit 1
+          fi
+
+          NORMALIZED_REPO_URL=$(echo "$REPO_URL" | sed -E 's|^git\+||; s|\.git$||')
+
+          if [ "$NORMALIZED_REPO_URL" != "$EXPECTED_REPO_URL" ]; then
+            echo "::error::package.json \"repository.url\" is \"${REPO_URL}\" (normalized: \"${NORMALIZED_REPO_URL}\"), but provenance expects \"${EXPECTED_REPO_URL}\". This will cause an E422 from npmjs.com. Fix the \"repository.url\" in your package.json."
+            exit 1
+          fi
+
+          echo "Validated: repository.url matches expected provenance source."
+
           PACKAGE_FILENAME=$(basename "$PACKAGE_TARBALL")
           if ! PACKAGE_SHA512=$(openssl dgst -sha512 -binary "$PACKAGE_TARBALL" | base64 | tr -d '\n'); then
             echo "::error::Failed to compute sha512 for tarball: $PACKAGE_TARBALL"

--- a/actions/attest-for-npmsjs-com/action.yml
+++ b/actions/attest-for-npmsjs-com/action.yml
@@ -27,6 +27,8 @@ runs:
       - name: Check if running on a GitHub-hosted runner
         if: ${{ runner.environment != 'github-hosted' }}
         shell: bash
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           echo "::error::This action must run on a GitHub-hosted runner. npmjs.com provenance verification rejects attestations generated on self-hosted runners (Runner Environment: \"$RUNNER_ENVIRONMENT\")."
           exit 1

--- a/actions/attest-for-npmsjs-com/action.yml
+++ b/actions/attest-for-npmsjs-com/action.yml
@@ -164,18 +164,18 @@ runs:
           ' <<<"$PACKAGE_JSON")
 
           if [ -z "$REPO_URL" ]; then
-            echo "::error::package.json is missing the \"repository\" field. npmjs.com provenance verification requires \"repository.url\" to match \"${EXPECTED_REPO_URL}\". Add to your package.json: \"repository\": { \"type\": \"git\", \"url\": \"${EXPECTED_REPO_URL}\" }"
+            echo "::error::package.json is missing a repository URL (\"repository\" string or \"repository.url\"). npmjs.com provenance verification requires the repository URL to match \"${EXPECTED_REPO_URL}\". Set in your package.json either \"repository\": \"${EXPECTED_REPO_URL}\" or \"repository\": { \"type\": \"git\", \"url\": \"${EXPECTED_REPO_URL}\" }."
             exit 1
           fi
 
           NORMALIZED_REPO_URL=$(printf '%s' "$REPO_URL" | sed -E 's|^git\+||; s|#.*$||; s|\.git$||; s|/*$||')
 
           if [ "$NORMALIZED_REPO_URL" != "$EXPECTED_REPO_URL" ]; then
-            echo "::error::package.json \"repository.url\" is \"${REPO_URL}\" (normalized: \"${NORMALIZED_REPO_URL}\"), but provenance expects \"${EXPECTED_REPO_URL}\". This will cause an E422 from npmjs.com. Fix the \"repository.url\" in your package.json."
+            echo "::error::package.json repository URL is \"${REPO_URL}\" (normalized: \"${NORMALIZED_REPO_URL}\"), but provenance expects \"${EXPECTED_REPO_URL}\". This will cause an E422 from npmjs.com. Fix the \"repository\" field in your package.json so its URL matches."
             exit 1
           fi
 
-          echo "Validated: repository.url matches expected provenance source."
+          echo "Validated: repository URL matches expected provenance source."
 
           PACKAGE_FILENAME=$(basename "$PACKAGE_TARBALL")
           if ! PACKAGE_SHA512=$(openssl dgst -sha512 -binary "$PACKAGE_TARBALL" | base64 | tr -d '\n'); then

--- a/actions/attest-for-npmsjs-com/action.yml
+++ b/actions/attest-for-npmsjs-com/action.yml
@@ -156,26 +156,21 @@ runs:
 
           EXPECTED_REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
 
-          REPO_URL=$(jq -r '
-            if .repository | type == "object" then .repository.url // ""
-            elif .repository | type == "string" then .repository
-            else ""
-            end
-          ' <<<"$PACKAGE_JSON")
+          REPO_URL=$(jq -r '.repository.url // ""' <<<"$PACKAGE_JSON")
 
           if [ -z "$REPO_URL" ]; then
-            echo "::error::package.json is missing a repository URL (\"repository\" string or \"repository.url\"). npmjs.com provenance verification requires the repository URL to match \"${EXPECTED_REPO_URL}\". Set in your package.json either \"repository\": \"${EXPECTED_REPO_URL}\" or \"repository\": { \"type\": \"git\", \"url\": \"${EXPECTED_REPO_URL}\" }."
+            echo "::error::package.json is missing \"repository.url\". npmjs.com provenance verification requires it to match \"${EXPECTED_REPO_URL}\". Add to your package.json: \"repository\": { \"type\": \"git\", \"url\": \"${EXPECTED_REPO_URL}\" }"
             exit 1
           fi
 
-          NORMALIZED_REPO_URL=$(printf '%s' "$REPO_URL" | sed -E 's|^git\+||; s|#.*$||; s|\.git$||; s|/*$||')
+          NORMALIZED_REPO_URL=$(echo "$REPO_URL" | sed -E 's|^git\+||; s|\.git$||')
 
           if [ "$NORMALIZED_REPO_URL" != "$EXPECTED_REPO_URL" ]; then
-            echo "::error::package.json repository URL is \"${REPO_URL}\" (normalized: \"${NORMALIZED_REPO_URL}\"), but provenance expects \"${EXPECTED_REPO_URL}\". This will cause an E422 from npmjs.com. Fix the \"repository\" field in your package.json so its URL matches."
+            echo "::error::package.json \"repository.url\" is \"${REPO_URL}\" (normalized: \"${NORMALIZED_REPO_URL}\"), expected \"${EXPECTED_REPO_URL}\". This mismatch will cause an E422 from npmjs.com."
             exit 1
           fi
 
-          echo "Validated: repository URL matches expected provenance source."
+          echo "Validated: repository.url matches expected provenance source."
 
           PACKAGE_FILENAME=$(basename "$PACKAGE_TARBALL")
           if ! PACKAGE_SHA512=$(openssl dgst -sha512 -binary "$PACKAGE_TARBALL" | base64 | tr -d '\n'); then

--- a/actions/attest-for-npmsjs-com/action.yml
+++ b/actions/attest-for-npmsjs-com/action.yml
@@ -23,6 +23,13 @@ runs:
         run: |
           echo "::error::This action only runs on public repositories. To avoid leaking private information, the action will be stopped."
           exit 1
+      # TODO: This restriction can be dropped once npmjs.com accepts attestations from self-hosted runners.
+      - name: Check if running on a GitHub-hosted runner
+        if: ${{ runner.environment != 'github-hosted' }}
+        shell: bash
+        run: |
+          echo "::error::This action must run on a GitHub-hosted runner. npmjs.com provenance verification rejects attestations generated on self-hosted runners (Runner Environment: \"$RUNNER_ENVIRONMENT\")."
+          exit 1
       - name: Set GitHub Path
         run: echo "$GITHUB_ACTION_PATH" >> "$GITHUB_PATH"
         shell: bash

--- a/actions/attest-for-npmsjs-com/action.yml
+++ b/actions/attest-for-npmsjs-com/action.yml
@@ -168,7 +168,7 @@ runs:
             exit 1
           fi
 
-          NORMALIZED_REPO_URL=$(echo "$REPO_URL" | sed -E 's|^git\+||; s|\.git$||')
+          NORMALIZED_REPO_URL=$(printf '%s' "$REPO_URL" | sed -E 's|^git\+||; s|#.*$||; s|\.git$||; s|/*$||')
 
           if [ "$NORMALIZED_REPO_URL" != "$EXPECTED_REPO_URL" ]; then
             echo "::error::package.json \"repository.url\" is \"${REPO_URL}\" (normalized: \"${NORMALIZED_REPO_URL}\"), but provenance expects \"${EXPECTED_REPO_URL}\". This will cause an E422 from npmjs.com. Fix the \"repository.url\" in your package.json."


### PR DESCRIPTION
## Summary

- Adds a **fail-fast validation** of `package.json` `repository.url` in the `attest-for-npmsjs-com` action, **before** the attestation is generated and uploaded.
- npmjs.com provenance verification requires `repository.url` to match the GitHub repository encoded in the sigstore bundle. Packages missing this field (or with a mismatched URL) fail with `E422` at publish time — after the attestation has already been created as an orphan.
- The check handles both object (`{ "url": "..." }`) and string (`"https://..."`) repository formats, and normalizes `git+` prefixes and `.git` suffixes that npm auto-adds.

## Context

Five `@ledgerhq/device-management-kit-devtools-*` packages failed to publish to npmjs.com with:

```
E422: package.json: "repository.url" is "", expected to match
"https://github.com/LedgerHQ/device-sdk-ts" from provenance
```

All five packages were missing the `repository` field entirely. This check would have caught the issue at attestation time with a clear, actionable error message telling the developer exactly what to add.

## Error messages

**Missing field:**
```
::error::package.json is missing the "repository" field. npmjs.com provenance
verification requires "repository.url" to match "https://github.com/Owner/repo".
Add to your package.json: "repository": { "type": "git", "url": "https://github.com/Owner/repo" }
```

**Mismatched URL:**
```
::error::package.json "repository.url" is "https://github.com/Wrong/repo"
(normalized: "https://github.com/Wrong/repo"), but provenance expects
"https://github.com/Owner/repo". This will cause an E422 from npmjs.com.
```

## Test plan

- [ ] Verify the action fails with a clear error when `repository` field is missing from `package.json`
- [ ] Verify the action fails with a clear error when `repository.url` doesn't match `GITHUB_REPOSITORY`
- [ ] Verify the action passes when `repository.url` matches (both object and string formats)
- [ ] Verify normalization handles `git+https://...git` format correctly


Made with [Cursor](https://cursor.com)