### PR TITLE
fix(jfrog-login): domain is empty due to using the wrong output

### DIFF
--- a/actions/jfrog-login/action.yml
+++ b/actions/jfrog-login/action.yml
@@ -52,7 +52,7 @@ runs:
       : Expose outputs as environment variables
       JFROG_DOMAIN=$(echo "${{ inputs.jfrog-url }}" | awk -F[/:] '{print $4}')
       echo "JFROG_DOMAIN=$JFROG_DOMAIN" >> $GITHUB_ENV
-      echo "JFROG_DOMAIN=$JFROG_DOMAIN" >> $GITHUB_OUTPUT
+      echo "jfrog-domain=$JFROG_DOMAIN" >> $GITHUB_OUTPUT
       echo "JFROG_USER=${{ steps.setup-jfrog-cli.outputs.oidc-user }}" >> $GITHUB_ENV
       echo "JFROG_TOKEN=${{ steps.setup-jfrog-cli.outputs.oidc-token }}" >> $GITHUB_ENV
       echo "JFROG_URL=${{ inputs.jfrog-url }}" >> $GITHUB_ENV


### PR DESCRIPTION
Fix the `jfrog-domain` output being currently empty due to bad casing on the `expose-outputs` step