### PR TITLE
feat!(wiz-cli): upgrade to Wiz CLI v1

### DIFF
--- a/actions/wiz-cli/README.md
+++ b/actions/wiz-cli/README.md
@@ -69,3 +69,5 @@ The Wiz credentials are stored as org-level variable and secret (`WIZ_CLIENT_ID_
 ```
 
 **Note**: At least one scan type (`dir_path` or `docker_tags`) must be specified for the action to run successfully.
+
+**Note**: This action only supports Linux x86_64 runners (e.g. `ubuntu-latest`).

--- a/actions/wiz-cli/README.md
+++ b/actions/wiz-cli/README.md
@@ -12,8 +12,8 @@ Designed for seamless integration within Ledger's CI/CD pipeline, the `wiz-cli` 
 
 | name | description | required | default |
 | --- | --- | --- | --- |
-| `iac_path` | <p>Path to the artifact, directory, or glob pattern to match files for IaC scan</p> | `false` | `""` |
-| `policy_iac` | <p>Policy to use for the IaC scan</p> | `false` | `""` |
+| `dir_path` | <p>Path to the directory to scan (IaC + secrets)</p> | `false` | `""` |
+| `policy_dir` | <p>Policy to use for the directory scan</p> | `false` | `""` |
 | `docker_tags` | <p>List of tags to scan (based on the output of the docker/metadata-action)</p> | `false` | `""` |
 | `policy_docker` | <p>Policy to use for the Docker scan</p> | `false` | `""` |
 | `wiz_client_id` | <p>Wiz API client ID for authentication</p> | `true` | `""` |
@@ -24,44 +24,48 @@ Designed for seamless integration within Ledger's CI/CD pipeline, the `wiz-cli` 
 
 <!-- action-docs-outputs source="action.yml" -->
 
+## Prerequisites
+
+The Wiz credentials are stored as org-level variable and secret (`WIZ_CLIENT_ID_20260417` / `WIZ_CLIENT_SECRET_20260417`). To use this action in a new repository, the repository must be added to the scope of these org-level credentials in **GitHub Settings > Organization > Secrets and variables > Actions**.
+
 ## Usage
 
-### IaC Scanning
+### Directory Scanning (IaC + Secrets)
 
 ```yaml
-- name: Wiz IaC Scan
-  uses: LedgerHQ/actions-security/feat-wiz-cli-init/actions/wiz-cli@actions/wiz-cli-1
+- name: Wiz Directory Scan
+  uses: LedgerHQ/actions-security/actions/wiz-cli@actions/wiz-cli-1
   with:
-    iac_path: "terraform/"
-    policy_iac: "iac-security-policy"
-    wiz_client_id: ${{ secrets.WIZ_CLIENT_ID }}
-    wiz_client_secret: ${{ secrets.WIZ_CLIENT_SECRET }}
+    dir_path: "terraform/"
+    policy_dir: "iac-security-policy"
+    wiz_client_id: ${{ vars.WIZ_CLIENT_ID_20260417 }}
+    wiz_client_secret: ${{ secrets.WIZ_CLIENT_SECRET_20260417 }}
 ```
 
 ### Docker Image Scanning
 
 ```yaml
 - name: Wiz Docker Scan
-  uses: LedgerHQ/actions-security/feat-wiz-cli-init/actions/wiz-cli@actions/wiz-cli-1
+  uses: LedgerHQ/actions-security/actions/wiz-cli@actions/wiz-cli-1
   with:
     docker_tags: "my-image:latest,my-image:v1.0.0"
     policy_docker: "container-security-policy"
-    wiz_client_id: ${{ secrets.WIZ_CLIENT_ID }}
-    wiz_client_secret: ${{ secrets.WIZ_CLIENT_SECRET }}
+    wiz_client_id: ${{ vars.WIZ_CLIENT_ID_20260417 }}
+    wiz_client_secret: ${{ secrets.WIZ_CLIENT_SECRET_20260417 }}
 ```
 
 ### Combined Scanning
 
 ```yaml
 - name: Wiz Security Scan
-  uses: LedgerHQ/actions-security/feat-wiz-cli-init/actions/wiz-cli@actions/wiz-cli-1
+  uses: LedgerHQ/actions-security/actions/wiz-cli@actions/wiz-cli-1
   with:
-    iac_path: "terraform/"
-    policy_iac: "iac-security-policy"
+    dir_path: "terraform/"
+    policy_dir: "iac-security-policy"
     docker_tags: "my-image:latest"
     policy_docker: "container-security-policy"
-    wiz_client_id: ${{ secrets.WIZ_CLIENT_ID }}
-    wiz_client_secret: ${{ secrets.WIZ_CLIENT_SECRET }}
+    wiz_client_id: ${{ vars.WIZ_CLIENT_ID_20260417 }}
+    wiz_client_secret: ${{ secrets.WIZ_CLIENT_SECRET_20260417 }}
 ```
 
-**Note**: At least one scan type (`iac_path` or `docker_tags`) must be specified for the action to run successfully.
+**Note**: At least one scan type (`dir_path` or `docker_tags`) must be specified for the action to run successfully.

--- a/actions/wiz-cli/action.yml
+++ b/actions/wiz-cli/action.yml
@@ -28,9 +28,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Download Wiz CLI v1
+    - name: Download and verify Wiz CLI v1
       shell: bash
-      run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
+      env:
+        WIZ_CLI_VERSION: "1.42.0-d3be05e219b3745829a3887e31a1c8f794102b4d"
+        WIZ_CLI_SHA256: "c1b9f4f7227028dfc9420ed051b24592b17050505dd8800a515d260a1a189aa1"
+      run: |
+        command -v curl >/dev/null 2>&1 || { echo "Error: curl is required but not installed."; exit 1; }
+        command -v sha256sum >/dev/null 2>&1 || { echo "Error: sha256sum is required but not installed."; exit 1; }
+        curl -fSL -o wizcli "https://downloads.wiz.io/v1/wizcli/${WIZ_CLI_VERSION}/wizcli-linux-amd64"
+        echo "${WIZ_CLI_SHA256}  wizcli" | sha256sum -c -
+        chmod +x wizcli
 
     - name: Validate scan configuration
       shell: bash

--- a/actions/wiz-cli/action.yml
+++ b/actions/wiz-cli/action.yml
@@ -2,15 +2,15 @@ name: "[Ledger Security] Wiz CLI Integration"
 author: LedgerHQ
 description: |
   The `wiz-cli` GitHub Action enables seamless integration with Wiz Cloud Security Platform via CLI. This action automates the installation and authentication of the Wiz CLI, allowing developers to perform various security operations such as scanning container images, infrastructure as code, and more.
-  
+
   Designed for seamless integration within Ledger's CI/CD pipeline, the `wiz-cli` action helps identify security issues early in the development lifecycle, ensuring compliance with security policies and best practices.
 
 inputs:
-  iac_path:
-    description: 'Path to the artifact, directory, or glob pattern to match files for IaC scan'
+  dir_path:
+    description: 'Path to the directory to scan (IaC + secrets)'
     default: ""
-  policy_iac:
-    description: 'Policy to use for the IaC scan'
+  policy_dir:
+    description: 'Policy to use for the directory scan'
     default: ""
   docker_tags:
     description: 'List of tags to scan (based on the output of the docker/metadata-action)'
@@ -24,51 +24,63 @@ inputs:
   wiz_client_secret:
     description: 'Wiz API client secret for authentication'
     required: true
-    
+
 runs:
   using: "composite"
   steps:
-    - name: Download Wiz CLI
+    - name: Download Wiz CLI v1
       shell: bash
-      run: curl -o wizcli https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
-
-    - name: Authenticate to Wiz
-      shell: bash
-      run: ./wizcli auth --id "${{ inputs.wiz_client_id }}" --secret "${{ inputs.wiz_client_secret }}"
+      run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
     - name: Validate scan configuration
       shell: bash
+      env:
+        DIR_PATH: ${{ inputs.dir_path }}
+        DOCKER_TAGS: ${{ inputs.docker_tags }}
       run: |
-        if [[ -z "${{ inputs.iac_path }}" && -z "${{ inputs.docker_tags }}" ]]; then
-          echo "Error: At least one scan type must be specified. Provide either 'iac_path' for IaC scanning or 'docker_tags' for Docker scanning."
+        if [[ -z "${DIR_PATH}" && -z "${DOCKER_TAGS}" ]]; then
+          echo "Error: At least one scan type must be specified. Provide either 'dir_path' for directory scanning or 'docker_tags' for Docker scanning."
           exit 1
         fi
 
-    - name: Run wiz CLI IaC scan
-      if: ${{ inputs.iac_path != '' }}
+    - name: Run Wiz CLI directory scan
+      if: ${{ inputs.dir_path != '' }}
       shell: bash
+      env:
+        WIZ_CLIENT_ID: ${{ inputs.wiz_client_id }}
+        WIZ_CLIENT_SECRET: ${{ inputs.wiz_client_secret }}
+        DIR_PATH: ${{ inputs.dir_path }}
+        POLICY_DIR: ${{ inputs.policy_dir }}
       run: |
-        SCAN_NAME="${{ github.repository }}-${{ github.ref }}"
-        if [[ -n "${{ inputs.policy_iac }}" ]]; then
-          ./wizcli iac scan --path "${{ inputs.iac_path }}" --discovered-resources --name "$SCAN_NAME" --policy "${{ inputs.policy_iac }}"
+        if [[ -n "${POLICY_DIR}" ]]; then
+          ./wizcli dir scan "${DIR_PATH}" --policy "${POLICY_DIR}"
         else
-          ./wizcli iac scan --path "${{ inputs.iac_path }}" --discovered-resources --name "$SCAN_NAME"
+          ./wizcli dir scan "${DIR_PATH}"
         fi
 
-    - name: Run wiz-cli docker image scan
+    - name: Run Wiz CLI Docker image scan
       if: ${{ inputs.docker_tags != '' }}
       shell: bash
+      env:
+        WIZ_CLIENT_ID: ${{ inputs.wiz_client_id }}
+        WIZ_CLIENT_SECRET: ${{ inputs.wiz_client_secret }}
+        DOCKER_TAGS: ${{ inputs.docker_tags }}
+        POLICY_DOCKER: ${{ inputs.policy_docker }}
+        SCAN_NAME: ${{ github.repository }}-${{ github.ref }}
       run: |
-        SCAN_NAME="${{ github.repository }}-${{ github.ref }}"
-        if [[ -n "${{ inputs.policy_docker }}" ]]; then
-          ./wizcli docker scan --image "${{ inputs.docker_tags }}" --name "$SCAN_NAME" --policy "${{ inputs.policy_docker }}"
+        if [[ -n "${POLICY_DOCKER}" ]]; then
+          ./wizcli docker scan --image "${DOCKER_TAGS}" --name "${SCAN_NAME}" --policy "${POLICY_DOCKER}"
         else
-          ./wizcli docker scan --image "${{ inputs.docker_tags }}" --name "$SCAN_NAME"
+          ./wizcli docker scan --image "${DOCKER_TAGS}" --name "${SCAN_NAME}"
         fi
 
-    - name: Fetch digest of Docker image for Graph enrichment
+    - name: Tag Docker image for Wiz graph enrichment
       if: ${{ inputs.docker_tags != '' }}
       shell: bash
+      env:
+        WIZ_CLIENT_ID: ${{ inputs.wiz_client_id }}
+        WIZ_CLIENT_SECRET: ${{ inputs.wiz_client_secret }}
+        DOCKER_TAGS: ${{ inputs.docker_tags }}
+        SCAN_NAME: ${{ github.repository }}-${{ github.ref }}
       run: |
-        SCAN_NAME="${{ github.repository }}-${{ github.ref }}"
-        ./wizcli docker tag --image "${{ inputs.docker_tags }}" --name "$SCAN_NAME"
+        ./wizcli tag --image "${DOCKER_TAGS}" --name "${SCAN_NAME}"


### PR DESCRIPTION
## Summary
- Upgrade wiz-cli action from v0 to v1
- Replace `wizcli iac scan` with `wizcli dir scan` (now covers IaC + secrets)
- Replace `wizcli docker tag` with `wizcli tag`
- Remove explicit `wizcli auth` step — v1 authenticates via `WIZ_CLIENT_ID`/`WIZ_CLIENT_SECRET` env vars
- Harden all `run:` blocks by moving `${{ }}` expressions to `env:` bindings
- Update README with new inputs, examples, prerequisites, and org secret names

## Breaking changes
- Input `iac_path` renamed to `dir_path`
- Input `policy_iac` renamed to `policy_dir`

## Repos to update after merge
- `tf-aws-production`
- `tf-aws-staging`
- `tf-aws-sandbox`
- `tf-cybersecurity`
- `runners-tests`

## Test plan
- [x] Create org variable `WIZ_CLIENT_ID_20260417` and secret `WIZ_CLIENT_SECRET_20260417`
- [ ] Test directory scan on a terraform repo (e.g. `tf-aws-sandbox`)
- [ ] Verify v0 consumers on `@actions/wiz-cli-0` are unaffected