### PR TITLE
chore: add CODEOWNERS for team-cybersecurity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @LedgerHQ/team-cybersecurity


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` to require team-cybersecurity review on all PRs
- Follows the same pattern as `secforge.ledger.ai` and `tf-jfrog`