### PR TITLE
fix(wiz-cli): correct CLI v1 command flags

### DIFF
--- a/actions/wiz-cli/action.yml
+++ b/actions/wiz-cli/action.yml
@@ -61,9 +61,9 @@ runs:
         POLICY_DIR: ${{ inputs.policy_dir }}
       run: |
         if [[ -n "${POLICY_DIR}" ]]; then
-          ./wizcli dir scan "${DIR_PATH}" --policy "${POLICY_DIR}"
+          ./wizcli dir scan --path "${DIR_PATH}" -p "${POLICY_DIR}"
         else
-          ./wizcli dir scan "${DIR_PATH}"
+          ./wizcli dir scan --path "${DIR_PATH}"
         fi
 
     - name: Run Wiz CLI Docker image scan
@@ -77,9 +77,9 @@ runs:
         SCAN_NAME: ${{ github.repository }}-${{ github.ref }}
       run: |
         if [[ -n "${POLICY_DOCKER}" ]]; then
-          ./wizcli docker scan --image "${DOCKER_TAGS}" --name "${SCAN_NAME}" --policy "${POLICY_DOCKER}"
+          ./wizcli docker scan -i "${DOCKER_TAGS}" --name "${SCAN_NAME}" -p "${POLICY_DOCKER}"
         else
-          ./wizcli docker scan --image "${DOCKER_TAGS}" --name "${SCAN_NAME}"
+          ./wizcli docker scan -i "${DOCKER_TAGS}" --name "${SCAN_NAME}"
         fi
 
     - name: Tag Docker image for Wiz graph enrichment
@@ -89,6 +89,5 @@ runs:
         WIZ_CLIENT_ID: ${{ inputs.wiz_client_id }}
         WIZ_CLIENT_SECRET: ${{ inputs.wiz_client_secret }}
         DOCKER_TAGS: ${{ inputs.docker_tags }}
-        SCAN_NAME: ${{ github.repository }}-${{ github.ref }}
       run: |
-        ./wizcli tag --image "${DOCKER_TAGS}" --name "${SCAN_NAME}"
+        ./wizcli tag "${DOCKER_TAGS}"


### PR DESCRIPTION
## Summary
Fix incorrect CLI flags based on `wizcli --help` output:
- `dir scan`: use `--path` flag instead of positional arg
- `docker scan`: use `-i` for image, `-p` for policy
- `tag`: positional arg only, no `--image` or `--name`

## Test plan
- [ ] Re-run wiz-cli scan on secforge terraform/