### PR TITLE
feat(wiz-cli): add disabled_scanners input

### DIFF
--- a/actions/wiz-cli/CHANGELOG.md
+++ b/actions/wiz-cli/CHANGELOG.md
@@ -20,12 +20,10 @@
 ### ⚠ BREAKING CHANGES
 
 * **wiz-cli:** input iac_path renamed to dir_path, policy_iac renamed to policy_dir
-* **wiz-cli:** input iac_path renamed to dir_path, policy_iac renamed to policy_dir
 
 ### Features
 
-* **wiz-cli:** upgrade to Wiz CLI v1 ([#87](https://github.com/LedgerHQ/actions-security/issues/87)) ([34e49a6](https://github.com/LedgerHQ/actions-security/commit/34e49a637086820c7e0b2936e02c57e10cd3323f))
-* **wiz-cli:** upgrade to Wiz CLI v1 ([#88](https://github.com/LedgerHQ/actions-security/issues/88)) ([04075dd](https://github.com/LedgerHQ/actions-security/commit/04075dd0b712a7094e378b92a8a6b92abcd241b7))
+* **wiz-cli:** upgrade to Wiz CLI v1 ([#84](https://github.com/LedgerHQ/actions-security/issues/84)) ([ce72159](https://github.com/LedgerHQ/actions-security/commit/ce72159238a3d3a3f4e21347817cdfa70478e726))
 
 ## 0.1.0 (2025-10-06)
 

--- a/actions/wiz-cli/README.md
+++ b/actions/wiz-cli/README.md
@@ -14,6 +14,7 @@ Designed for seamless integration within Ledger's CI/CD pipeline, the `wiz-cli` 
 | --- | --- | --- | --- |
 | `dir_path` | <p>Path to the directory to scan (IaC + secrets)</p> | `false` | `""` |
 | `policy_dir` | <p>Policy to use for the directory scan</p> | `false` | `""` |
+| `disabled_scanners` | <p>Comma-separated list of scanners to disable for the directory scan (supported: Vulnerability, Secret, SensitiveData, Misconfiguration, SoftwareSupplyChain, AIModels, SAST, Malware)</p> | `false` | `""` |
 | `docker_tags` | <p>List of tags to scan (based on the output of the docker/metadata-action)</p> | `false` | `""` |
 | `policy_docker` | <p>Policy to use for the Docker scan</p> | `false` | `""` |
 | `wiz_client_id` | <p>Wiz API client ID for authentication</p> | `true` | `""` |
@@ -38,6 +39,20 @@ The Wiz credentials are stored as org-level variable and secret. To use this act
   with:
     dir_path: "terraform/"
     policy_dir: "iac-security-policy"
+    wiz_client_id: ${{ vars.WIZ_CLIENT_ID }}
+    wiz_client_secret: ${{ secrets.WIZ_CLIENT_SECRET }}
+```
+
+### Directory Scanning with selected scanners only
+
+Run only Misconfiguration + Secret scanners (disable everything else):
+
+```yaml
+- name: Wiz Directory Scan (IaC + Secrets only)
+  uses: LedgerHQ/actions-security/actions/wiz-cli@actions/wiz-cli-1
+  with:
+    dir_path: "terraform/"
+    disabled_scanners: "Vulnerability,SensitiveData,SoftwareSupplyChain,AIModels,SAST,Malware"
     wiz_client_id: ${{ vars.WIZ_CLIENT_ID }}
     wiz_client_secret: ${{ secrets.WIZ_CLIENT_SECRET }}
 ```

--- a/actions/wiz-cli/action.yml
+++ b/actions/wiz-cli/action.yml
@@ -12,6 +12,9 @@ inputs:
   policy_dir:
     description: 'Policy to use for the directory scan'
     default: ""
+  disabled_scanners:
+    description: 'Comma-separated list of scanners to disable for the directory scan (supported: Vulnerability, Secret, SensitiveData, Misconfiguration, SoftwareSupplyChain, AIModels, SAST, Malware)'
+    default: ""
   docker_tags:
     description: 'List of tags to scan (based on the output of the docker/metadata-action)'
     default: ""
@@ -59,12 +62,16 @@ runs:
         WIZ_CLIENT_SECRET: ${{ inputs.wiz_client_secret }}
         DIR_PATH: ${{ inputs.dir_path }}
         POLICY_DIR: ${{ inputs.policy_dir }}
+        DISABLED_SCANNERS: ${{ inputs.disabled_scanners }}
       run: |
+        ARGS=(scan dir "${DIR_PATH}")
         if [[ -n "${POLICY_DIR}" ]]; then
-          ./wizcli dir scan --path "${DIR_PATH}" -p "${POLICY_DIR}"
-        else
-          ./wizcli dir scan --path "${DIR_PATH}"
+          ARGS+=(-p "${POLICY_DIR}")
         fi
+        if [[ -n "${DISABLED_SCANNERS}" ]]; then
+          ARGS+=(--disabled-scanners "${DISABLED_SCANNERS}")
+        fi
+        ./wizcli "${ARGS[@]}"
 
     - name: Run Wiz CLI Docker image scan
       if: ${{ inputs.docker_tags != '' }}
@@ -76,11 +83,11 @@ runs:
         POLICY_DOCKER: ${{ inputs.policy_docker }}
         SCAN_NAME: ${{ github.repository }}-${{ github.ref }}
       run: |
+        ARGS=(scan container-image "${DOCKER_TAGS}" --name "${SCAN_NAME}")
         if [[ -n "${POLICY_DOCKER}" ]]; then
-          ./wizcli docker scan -i "${DOCKER_TAGS}" --name "${SCAN_NAME}" -p "${POLICY_DOCKER}"
-        else
-          ./wizcli docker scan -i "${DOCKER_TAGS}" --name "${SCAN_NAME}"
+          ARGS+=(-p "${POLICY_DOCKER}")
         fi
+        ./wizcli "${ARGS[@]}"
 
     - name: Tag Docker image for Wiz graph enrichment
       if: ${{ inputs.docker_tags != '' }}


### PR DESCRIPTION
Expose Wiz CLI v1 --disabled-scanners flag so callers can opt out of specific scanners (Vulnerability, Secret, SensitiveData, Misconfiguration, SoftwareSupplyChain, AIModels, SAST, Malware). Also deduplicates CHANGELOG 1.0.0 entries.