### PR TITLE
feat(workflow-scan): add workflow-scan composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A collection of reusable GitHub Actions for automating **artifact signing**, **a
 | **[jfrog-login](actions/jfrog-login)** | `actions/jfrog-login-1` | Secure OIDC-based login to Ledger's JFrog platform (Artifactory & Xray) |
 | **[jfrog-npm](actions/jfrog-npm)** | `actions/jfrog-npm-1` | Configure `.npmrc` for npm/pnpm/yarn to authenticate with JFrog |
 | **[wiz-cli](actions/wiz-cli)** | `actions/wiz-cli-1` | Integrate with Wiz Cloud Security for IaC and container image scanning |
+| **[workflow-scan](actions/workflow-scan)** | `actions/workflow-scan-1` | Scan GitHub Actions workflows with Trajan and octoscan |
 
 ---
 

--- a/actions/workflow-scan/CHANGELOG.md
+++ b/actions/workflow-scan/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Changelog
+
+## 0.1.0
+
+- Initial release.

--- a/actions/workflow-scan/CHANGELOG.md
+++ b/actions/workflow-scan/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/actions/workflow-scan/LICENSE
+++ b/actions/workflow-scan/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ledger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/actions/workflow-scan/README.md
+++ b/actions/workflow-scan/README.md
@@ -1,0 +1,91 @@
+# GitHub Action: `workflow-scan`
+
+
+
+## Description
+
+The `workflow-scan` GitHub Action runs two complementary GitHub Actions workflow security scanners:
+
+- **Trajan** ([praetorian-inc/trajan](https://github.com/praetorian-inc/trajan)) — API-backed scan that queries the GitHub API for workflow definitions on the merged ref.
+- **octoscan** ([synacktiv/octoscan](https://github.com/synacktiv/octoscan)) — static YAML analysis of `.github/workflows/`.
+
+Both binaries are pinned by version and verified by SHA-256 before installation. Designed for seamless integration within Ledger's CI/CD pipeline, ensuring that GitHub Actions workflows follow security best practices and are free from common misconfigurations.
+
+## Usage
+
+### Permissions
+
+To enable this action to work properly, ensure the following permissions are set in your workflow:
+
+```yaml
+permissions:
+    contents: read
+```
+
+### Example Workflow
+
+Trajan queries the GitHub API for workflows on the merged ref, so it can only run on the default branch. Use it as a **post-merge scan** (e.g. on `push` to `main`):
+
+```yaml
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run workflow scan
+        uses: LedgerHQ/actions-security/actions/workflow-scan@actions/workflow-scan-1
+```
+
+The default `GITHUB_TOKEN` is sufficient for Trajan's GitHub API scan; no extra secrets need to be passed.
+
+
+
+## Inputs
+
+
+| name               | description                                                                  | required | default                                                              |
+| ------------------ | ---------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------- |
+| `trajan-enabled`   | Enable the Trajan GitHub API scan                                            | `false`  | `"true"`                                                             |
+| `trajan-version`   | Trajan release version                                                       | `false`  | `"1.0.1"`                                                            |
+| `trajan-sha256`    | Expected SHA-256 digest of the Trajan binary                                 | `false`  | `"133486f9ddc12c7b20ca19c3100a4dbdfb0fba5066e7dc9322db6f67baa16609"` |
+| `octoscan-enabled` | Enable the octoscan static analysis scan                                     | `false`  | `"true"`                                                             |
+| `octoscan-version` | octoscan release version                                                     | `false`  | `"0.1.7"`                                                            |
+| `octoscan-sha256`  | Expected SHA-256 digest of the octoscan binary                               | `false`  | `"6435e9cc0e6346741367cbb1803e5b545d8e7031d188c733a0b30f768ab6ebe2"` |
+| `token`            | GitHub token for the Trajan API scan (defaults to the workflow GITHUB_TOKEN) | `false`  | `${{ github.token }}`                                                |
+
+
+
+
+
+
+
+
+## Pinned versions
+
+
+| Tool     | Version | SHA-256                                                            |
+| -------- | ------- | ------------------------------------------------------------------ |
+| Trajan   | `1.0.1` | `133486f9ddc12c7b20ca19c3100a4dbdfb0fba5066e7dc9322db6f67baa16609` |
+| octoscan | `0.1.7` | `6435e9cc0e6346741367cbb1803e5b545d8e7031d188c733a0b30f768ab6ebe2` |
+
+
+## Runs
+
+This action is a **composite action**, which allows us to combine multiple workflow steps into a single, reusable action. This promotes modularity and simplifies our workflows.
+
+## Notes
+
+- Only Linux x86_64 runners (e.g. `ubuntu-latest`) are supported.
+- octoscan is invoked with `--disable-rules shellcheck,local-action --filter-triggers external`.
+

--- a/actions/workflow-scan/action.yml
+++ b/actions/workflow-scan/action.yml
@@ -1,0 +1,92 @@
+name: "[Ledger Security] Workflow Scan"
+author: LedgerHQ
+description: |
+  The `workflow-scan` GitHub Action runs two complementary GitHub Actions workflow security scanners:
+
+  - **Trajan** — API-backed scan that queries the GitHub API for workflow definitions on the merged ref.
+  - **octoscan** — static YAML analysis of `.github/workflows/`.
+
+  Both binaries are pinned by version and verified by SHA-256 before installation. Designed for seamless integration within Ledger's CI/CD pipeline, ensuring that GitHub Actions workflows follow security best practices and are free from common misconfigurations.
+
+inputs:
+  trajan-enabled:
+    description: 'Enable the Trajan GitHub API scan'
+    required: false
+    default: "true"
+  trajan-version:
+    description: 'Trajan release version'
+    required: false
+    default: "1.0.1"
+  trajan-sha256:
+    description: 'Expected SHA-256 digest of the Trajan binary'
+    required: false
+    default: "133486f9ddc12c7b20ca19c3100a4dbdfb0fba5066e7dc9322db6f67baa16609"
+  octoscan-enabled:
+    description: 'Enable the octoscan static analysis scan'
+    required: false
+    default: "true"
+  octoscan-version:
+    description: 'octoscan release version'
+    required: false
+    default: "0.1.7"
+  octoscan-sha256:
+    description: 'Expected SHA-256 digest of the octoscan binary'
+    required: false
+    default: "6435e9cc0e6346741367cbb1803e5b545d8e7031d188c733a0b30f768ab6ebe2"
+  token:
+    description: 'GitHub token for the Trajan API scan (defaults to the workflow GITHUB_TOKEN)'
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Trajan
+      if: ${{ inputs.trajan-enabled == 'true' }}
+      shell: bash
+      env:
+        TRAJAN_VERSION: ${{ inputs.trajan-version }}
+        TRAJAN_SHA256: ${{ inputs.trajan-sha256 }}
+      run: |
+        set -euo pipefail
+        WORK="$(mktemp -d)"
+        curl -sSL \
+          "https://github.com/praetorian-inc/trajan/releases/download/v${TRAJAN_VERSION}/trajan_${TRAJAN_VERSION}_linux_amd64.tar.gz" \
+          -o "${WORK}/trajan.tgz"
+        echo "${TRAJAN_SHA256}  ${WORK}/trajan.tgz" | sha256sum --check --strict
+        tar -xzf "${WORK}/trajan.tgz" -C "${WORK}"
+        sudo install -m 0755 "${WORK}/trajan" /usr/local/bin/trajan
+        rm -rf "${WORK}"
+
+    - name: Scan repository via GitHub API (Trajan)
+      if: ${{ inputs.trajan-enabled == 'true' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        trajan github scan --repo "${REPO}" --token "${GH_TOKEN}" --detailed
+
+    - name: Install octoscan
+      if: ${{ inputs.octoscan-enabled == 'true' }}
+      shell: bash
+      env:
+        OCTOSCAN_VERSION: ${{ inputs.octoscan-version }}
+        OCTOSCAN_SHA256: ${{ inputs.octoscan-sha256 }}
+      run: |
+        set -euo pipefail
+        WORK="$(mktemp -d)"
+        curl -sSL \
+          "https://github.com/synacktiv/octoscan/releases/download/v${OCTOSCAN_VERSION}/octoscan" \
+          -o "${WORK}/octoscan"
+        echo "${OCTOSCAN_SHA256}  ${WORK}/octoscan" | sha256sum --check --strict
+        sudo install -m 0755 "${WORK}/octoscan" /usr/local/bin/octoscan
+        rm -rf "${WORK}"
+
+    - name: Scan workflows (octoscan)
+      if: ${{ inputs.octoscan-enabled == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        octoscan scan .github/workflows/ --disable-rules shellcheck,local-action --filter-triggers external

--- a/actions/workflow-scan/action.yml
+++ b/actions/workflow-scan/action.yml
@@ -9,83 +9,54 @@ description: |
   Both binaries are pinned by version and verified by SHA-256 before installation. Designed for seamless integration within Ledger's CI/CD pipeline, ensuring that GitHub Actions workflows follow security best practices and are free from common misconfigurations.
 
 inputs:
-  trajan-enabled:
-    description: 'Enable the Trajan GitHub API scan'
-    required: false
-    default: "true"
-  trajan-version:
-    description: 'Trajan release version'
-    required: false
-    default: "1.0.1"
-  trajan-sha256:
-    description: 'Expected SHA-256 digest of the Trajan binary'
-    required: false
-    default: "133486f9ddc12c7b20ca19c3100a4dbdfb0fba5066e7dc9322db6f67baa16609"
-  octoscan-enabled:
-    description: 'Enable the octoscan static analysis scan'
-    required: false
-    default: "true"
-  octoscan-version:
-    description: 'octoscan release version'
-    required: false
-    default: "0.1.7"
-  octoscan-sha256:
-    description: 'Expected SHA-256 digest of the octoscan binary'
-    required: false
-    default: "6435e9cc0e6346741367cbb1803e5b545d8e7031d188c733a0b30f768ab6ebe2"
   token:
     description: 'GitHub token for the Trajan API scan (defaults to the workflow GITHUB_TOKEN)'
     required: false
-    default: ${{ github.token }}
+    default: ''
 
 runs:
   using: "composite"
   steps:
     - name: Install Trajan
-      if: ${{ inputs.trajan-enabled == 'true' }}
       shell: bash
-      env:
-        TRAJAN_VERSION: ${{ inputs.trajan-version }}
-        TRAJAN_SHA256: ${{ inputs.trajan-sha256 }}
       run: |
         set -euo pipefail
+        TRAJAN_VERSION="1.0.1"
+        TRAJAN_SHA256="133486f9ddc12c7b20ca19c3100a4dbdfb0fba5066e7dc9322db6f67baa16609"
         WORK="$(mktemp -d)"
         curl -sSL \
           "https://github.com/praetorian-inc/trajan/releases/download/v${TRAJAN_VERSION}/trajan_${TRAJAN_VERSION}_linux_amd64.tar.gz" \
           -o "${WORK}/trajan.tgz"
         echo "${TRAJAN_SHA256}  ${WORK}/trajan.tgz" | sha256sum --check --strict
         tar -xzf "${WORK}/trajan.tgz" -C "${WORK}"
-        sudo install -m 0755 "${WORK}/trajan" /usr/local/bin/trajan
+        install -m 0755 "${WORK}/trajan" "${RUNNER_TEMP}/trajan"
+        echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
         rm -rf "${WORK}"
 
     - name: Scan repository via GitHub API (Trajan)
-      if: ${{ inputs.trajan-enabled == 'true' }}
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.token }}
+        GH_TOKEN: ${{ inputs.token || github.token }}
         REPO: ${{ github.repository }}
       run: |
         set -euo pipefail
         trajan github scan --repo "${REPO}" --token "${GH_TOKEN}" --detailed
 
     - name: Install octoscan
-      if: ${{ inputs.octoscan-enabled == 'true' }}
       shell: bash
-      env:
-        OCTOSCAN_VERSION: ${{ inputs.octoscan-version }}
-        OCTOSCAN_SHA256: ${{ inputs.octoscan-sha256 }}
       run: |
         set -euo pipefail
+        OCTOSCAN_VERSION="0.1.7"
+        OCTOSCAN_SHA256="6435e9cc0e6346741367cbb1803e5b545d8e7031d188c733a0b30f768ab6ebe2"
         WORK="$(mktemp -d)"
         curl -sSL \
           "https://github.com/synacktiv/octoscan/releases/download/v${OCTOSCAN_VERSION}/octoscan" \
           -o "${WORK}/octoscan"
         echo "${OCTOSCAN_SHA256}  ${WORK}/octoscan" | sha256sum --check --strict
-        sudo install -m 0755 "${WORK}/octoscan" /usr/local/bin/octoscan
+        install -m 0755 "${WORK}/octoscan" "${RUNNER_TEMP}/octoscan"
         rm -rf "${WORK}"
 
     - name: Scan workflows (octoscan)
-      if: ${{ inputs.octoscan-enabled == 'true' }}
       shell: bash
       run: |
         set -euo pipefail

--- a/actions/workflow-scan/action.yml
+++ b/actions/workflow-scan/action.yml
@@ -40,7 +40,7 @@ runs:
         REPO: ${{ github.repository }}
       run: |
         set -euo pipefail
-        trajan github scan --repo "${REPO}" --token "${GH_TOKEN}" --detailed
+        trajan github scan --repo "${REPO}" --detailed
 
     - name: Install octoscan
       shell: bash


### PR DESCRIPTION
Add a new composite action under actions/workflow-scan/ that runs Trajan and octoscan for GitHub Actions workflow security scanning. Remove the standalone reusable workflow (workflow-scanning.yml).

Please tell me what you think about letting developers control the inputs.