### PR TITLE
fix(jfrog): update `jfrog/setup-jfrog-cli` to `v5`

### DIFF
--- a/actions/jfrog-login/action.yml
+++ b/actions/jfrog-login/action.yml
@@ -39,7 +39,7 @@ runs:
         exit 1
       fi
     shell: bash
-  - uses: jfrog/setup-jfrog-cli@v4
+  - uses: jfrog/setup-jfrog-cli@v5
     id: setup-jfrog-cli
     env:
       JF_URL: ${{ inputs.jfrog-url }}


### PR DESCRIPTION
Upgrade to `jfrog/setup-jfrog-cli@v5` which moves from the deprecated Node 20 to Node 24, removing the GitHub action warning triggered by every JFrog auth in every job (leading to job summary flooding)